### PR TITLE
Env var config

### DIFF
--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -1,111 +1,158 @@
+// Package cfg is for loading application config with override capability for different environments.
 package cfg
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
-	"log/syslog"
+	"os"
+	"reflect"
 	"strconv"
+	"strings"
 )
 
+// the directory to look for config override files in.
+var over = "/etc/sysconfig"
+
 type Config struct {
-	DataBase  DataBase
-	WebServer WebServer
-	SQS       SQS
+	DataBase  *DataBase
+	WebServer *WebServer
+	SQS       *SQS
+	Env       *Env
+	Librato   *Librato
 }
 
+// DataBase for database config.  Elements with an env tag can be overidden via env var.  See Load.
 type DataBase struct {
-	Host              string // database host name.  Often `localhost`.
-	Name              string // the name of the database to connect to on the host e.g., `fits`
-	User              string // user to connect to the database.
-	Password          string // password (unencrypted) for the database user.
-	SSLMode           string // SSL mode for the DB connection.  Usually `disable` or `require`.
-	MaxOpenConns      int    // max open connections for the database connection pool.
-	MaxIdleConns      int    // max number of idle connections to maintain in the database connection pool.
-	ConnectionTimeOut int    // timeout in seconds for trying to connect to the database.
+	Host              string `doc:"database host name." env:"${PREFIX}_DATABASE_HOST"`
+	Name              string `doc:"database name on Host."`
+	User              string `doc:"database user."`
+	Password          string `doc:"database User password (unencrypted)." env:"${PREFIX}_DATABASE_PASSWORD"`
+	SSLMode           string `doc:"usually disable or require." env:"${PREFIX}_DATABASE_SSL_MODE"`
+	MaxOpenConns      int    `doc:"database connection pool." env:"${PREFIX}_DATABASE_MAX_OPEN_CONNS"`
+	MaxIdleConns      int    `doc:"database connection pool." env:"${PREFIX}_DATABASE_MAX_IDLE_CONNS"`
+	ConnectionTimeOut int    `doc:"database connect timeout."`
 }
 
+type Env struct {
+	Prefix string `doc:"prefix for env vars.  Provides env var name space."`
+}
+
+// WebServer for web server config.  Elements with an env tag can be overidden via env var.  See Load.
 type WebServer struct {
-	Port       string // the port for the web server to listen for connections on e.g., `8080`
-	CNAME      string // the public CNAME for the service.
-	Production bool   // set true if the application is running in production mode.
+	Port       string `doc:"web server port." env:"${PREFIX}_WEB_SERVER_PORT"`
+	CNAME      string `doc:"public CNAME for the service." env:"${PREFIX}_WEB_SERVER_CNAME"`
+	Production bool   `doc:"true if the app is production." env:"${PREFIX}_WEB_SERVER_PRODUCTION"`
 }
 
+// SQS for AWS SQS config.  Elements with an env tag can be overidden via env var.  See Load.
 type SQS struct {
-	AWSRegion, QueueName, AccessKey, SecretKey string
-	NumberOfListeners                          int // controls the number of concurrent SQS messages listeners that will be started.
+	AWSRegion         string `doc:"SQS region e.g., ap-southeast-2." env:"${PREFIX}_SQS_AWS_REGION"`
+	QueueName         string `doc:"SQS queue name." env:"${PREFIX}_SQS_QUEUE_NAME"`
+	AccessKey         string `doc:"SQS queue user access key." env:"${PREFIX}_SQS_ACCESS_KEY"`
+	SecretKey         string `doc:"SQS queue user secret." env:"${PREFIX}_SQS_SECRET_KEY"`
+	NumberOfListeners int    `doc:"number of SQS listeners." env:"${PREFIX}_SQS_NUMBER_OF_LISTENERS"`
 }
 
-// LoadConfig locates and loads the JSON file containing Config information for an appliation.  See the
-// Config struct in this package.
-// name is the name of the file to try to load e.g., `fits`.  This would usually be the name of the appliction.  LoadConfig
-// then looks for a file `name`.json to load Config from.  It tries /etc/sysconfig  first and if it does not
-// find a file to load there it falls back the directory the application was started from.
+type Librato struct {
+	User string `doc:"username for Librato." env:"LIBRATO_USER"` // no PREFIX for Librato - one per host is plenty.
+	Key  string `doc:"key for Librato." env:"LIBRATO_KEY"`
+}
+
+func (c *Config) env() {
+	if c.Env != nil {
+		env(c.Env.Prefix, c.DataBase)
+		env(c.Env.Prefix, c.WebServer)
+		env(c.Env.Prefix, c.SQS)
+		env(c.Env.Prefix, c.Librato)
+	}
+}
+
+// Load loads config from JSON with options to override from the file system and environment variables.
+// Load looks for a JSON file that matched the executable name suffixed with JSON.  If a JSON file is found
+// and successfully loaded then environment variables with config.Env.Prefix are used to override the config.
+// Failure to find and parse a JSON config file is a fatal error.
 //
-// If the config file is succesfully loaded from /etc/sysconfig the application is switched to using syslog.
+// For application foo with config.Env.Prefix FOO the load order is:
+//   * Try to load /etc/sysconfig/foo.json
+//   * If /etc/sysconfig/foo.json is not found then try to load ./foo.json
+//   * Check the environment vars for any appropriate vars prefixed with FOO_ and override the config vals.
+//     For example an env var FOO_DATABASE_PASSWORD will be read and override config.DataBase.Password
+//   * Return config.
 //
-// If a config file can't be found or parsed then log.Fatal is called which will log and error then call os.Exit(1).
+// Load can be used to init a var so that config will be available before init() funcs are called:
+//   var config = cfg.Load()
 //
-// Config can be made available early in an applications lifecycle (before init() is called) by using this function
-// to init a var e.g.,
+// If override of config from
+// environment vars would change application behaviour then it may be appropriate to override config elements after Load e.g.,
+//   var config = cfg.Load()
 //
-//    var (
-//    	config = cfg.LoadConfig("fits")
-//    )
+//   func init() {
+//	config.SQS.NumberOfListeners = 1
+//     }
 //
-// A config JSON file looks like:
-// Config holds configuration applications e.g.,
-//    {
-//    	"DataBase": {
-//    		"Host": "localhost",
-//    		"Name": "fits",
-//    		"User": "fits_r",
-//    		"Password": "test",
-//    		"MaxOpenConns": 30,
-//    		"MaxIdleConns": 20,
-//    		"ConnectionTimeOut": 5,
-//    		"SSLMode": "disable"
-//    	},
-//    	"WebServer": {
-//    		"Port": "8080",
-//                     "CNAME": "my.cool.service"
-//    	            "Production": false
-//    	},
-//           "SQS": {
+// The config file should be JSON that will parse into Config.  A complete example is shown below.  Objects can be omitted
+// if not required e.g., if there is no SQS object in the JSON then Config will have a nil SQS pointer.  Elements of objects that
+// are omitted in the JSON will have the corresponding type zero value in Config.
+//
+//   {
+// 	"DataBase": {
+// 		"Host": "localhost",
+// 		"Name": "test",
+// 		"User": "test_w",
+// 		"Password": "test",
+// 		"MaxOpenConns": 1,
+// 		"MaxIdleConns": 2,
+// 		"ConnectionTimeOut": 30,
+// 		"SSLMode": "disable"
+// 	},
+// 	"SQS": {
 // 		"AWSRegion": "ap-southeast-2",
 // 		"QueueName": "XXX",
 // 		"AccessKey": "XXX",
 // 		"SecretKey": "XXX",
 // 		"NumberOfListeners": 1
 // 	},
-//    }
-func Load(name string) Config {
+// 	"WebServer": {
+// 		"Port": "8080",
+// 		"CNAME": "thing,com",
+// 		"Production": false
+// 	},
+//         "Env": {
+//                    "Prefix": "PREFIX"
+//         },
+//         "Librato": {
+//	           "User": "XXX",
+//                    "Key": "XXX"
+//         }
+//   }
+func Load() Config {
+	a := strings.Split(os.Args[0], "/")
+	name := a[len(a)-1]
 	log.SetPrefix(name + " ")
 
 	c := name + ".json"
+	ov := over + "/" + c
 
-	f, err := ioutil.ReadFile("/etc/sysconfig/" + c)
+	f, err := ioutil.ReadFile(ov)
 	if err != nil {
-		log.Println("Could not load /etc/sysconfig/" + c + " falling back to local file.")
+		log.Printf("Could not load %s falling back to local file.", ov)
 		f, err = ioutil.ReadFile("./" + c)
 		if err != nil {
-			log.Println("Can't find any config for " + name)
+			log.Println("ERROR can't find any config for " + name)
 			log.Fatal(err)
-		}
-	} else {
-		logwriter, err := syslog.New(syslog.LOG_NOTICE, name)
-		if err == nil {
-			log.Println("** logging to syslog **")
-			log.SetOutput(logwriter)
 		}
 	}
 
 	var d Config
 	err = json.Unmarshal(f, &d)
 	if err != nil {
-		log.Println("Problem parsing config file.")
+		log.Println("ERROR problem parsing config file.")
 		log.Fatal(err)
 	}
+
+	d.env()
 
 	return d
 }
@@ -118,4 +165,108 @@ func (d *DataBase) Postgres() string {
 		" password=" + d.Password +
 		" dbname=" + d.Name +
 		" sslmode=" + d.SSLMode
+}
+
+// env takes v, a pointer to a struct and prefix, a string that is used for env var prefixes.
+// It checks elements of the struct in v for tags "env:${PREFIX}_VAR_NAME".  If there is
+// tag env then env var ${PREFIX}_VAR_NAME is loaded and parsed then element in v
+// set to the env var value.
+func env(prefix string, v interface{}) {
+	if reflect.ValueOf(v).IsNil() {
+		return
+	}
+
+	if reflect.TypeOf(v).Kind() != reflect.Ptr {
+		return
+	}
+
+	if reflect.ValueOf(v).Elem().Kind() != reflect.Struct {
+		return
+	}
+
+	e := reflect.TypeOf(v).Elem().Name()
+
+	st := reflect.TypeOf(v).Elem()
+	sv := reflect.ValueOf(v).Elem()
+
+	for i := 0; i < st.NumField(); i++ {
+		field := st.Field(i)
+		if key := field.Tag.Get("env"); key != "" {
+			key = strings.Replace(key, "${PREFIX}", prefix, 1)
+			val := os.Getenv(key)
+			if val != "" {
+				switch field.Type.Kind() {
+				case reflect.String:
+					// don't log anything that might be sensitive data from the ENV
+					log.Printf("overriding config %s.%s from env %s", e, field.Name, key)
+					sv.Field(i).SetString(val)
+				case reflect.Int:
+					if n, err := strconv.ParseInt(val, 10, 64); err == nil {
+						log.Printf("overriding config %s.%s from env %s", e, field.Name, key)
+						sv.Field(i).SetInt(n)
+					} else {
+						log.Printf("ERROR parsing %s=%s from env as int: %s", key, val, err)
+					}
+				case reflect.Bool:
+					if b, err := strconv.ParseBool(val); err == nil {
+						log.Printf("overriding config %s.%s from env %s", e, field.Name, key)
+						sv.Field(i).SetBool(b)
+					} else {
+						log.Printf("ERROR parsing %s=%s from env as bool: %s", key, val, err)
+
+					}
+				}
+			}
+		}
+	}
+}
+
+type EnvDoc struct {
+	Key, Val, Doc string
+}
+
+// EnvDoc returns information about Config values that can be overridden from env vars.
+func (c *Config) EnvDoc() (d []EnvDoc, err error) {
+	if c.Env != nil {
+		d = append(d, envDoc(c.Env.Prefix, c.DataBase)...)
+		d = append(d, envDoc(c.Env.Prefix, c.WebServer)...)
+		d = append(d, envDoc(c.Env.Prefix, c.SQS)...)
+		d = append(d, envDoc(c.Env.Prefix, c.Librato)...)
+	} else {
+		err = fmt.Errorf("Found nil Prefix in the config.  Don't know how to read env var.")
+	}
+
+	return
+}
+
+func envDoc(prefix string, v interface{}) (d []EnvDoc) {
+	if reflect.ValueOf(v).IsNil() {
+		return
+	}
+
+	if reflect.TypeOf(v).Kind() != reflect.Ptr {
+		return
+	}
+
+	if reflect.ValueOf(v).Elem().Kind() != reflect.Struct {
+		return
+	}
+
+	st := reflect.TypeOf(v).Elem()
+	sv := reflect.ValueOf(v).Elem()
+
+	for i := 0; i < st.NumField(); i++ {
+		field := st.Field(i)
+		if key := field.Tag.Get("env"); key != "" {
+			key = strings.Replace(key, "${PREFIX}", prefix, 1)
+			doc := EnvDoc{
+				Key: key,
+				Val: fmt.Sprintf("%v", sv.Field(i).Interface()),
+				Doc: field.Tag.Get("doc"),
+			}
+			d = append(d, doc)
+		}
+	}
+
+	return
 }

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -8,36 +8,10 @@ import (
 	"strconv"
 )
 
-// Config holds configuration applications e.g.,
-//    {
-//    	"DataBase": {
-//    		"Host": "localhost",
-//    		"Name": "fits",
-//    		"User": "fits_r",
-//    		"Password": "test",
-//    		"MaxOpenConns": 30,
-//    		"MaxIdleConns": 20,
-//    		"ConnectionTimeOut": 5,
-//    		"SSLMode": "disable"
-//    	},
-//    	"Server": {
-//    		"Port": "8080",
-//                        "CNAME": "my.cool.service"
-//    	},
-//           "SQS": {
-// 		"AWSRegion": "ap-southeast-2",
-// 		"QueueName": "XXX",
-// 		"AccessKey": "XXX",
-// 		"SecretKey": "XXX",
-// 		"NumberOfListeners": 1
-// 	},
-//    	"Production": false
-//    }
 type Config struct {
-	DataBase   DataBase
-	Server     Server
-	SQS        SQS
-	Production bool // set true if the application is running in production mode.
+	DataBase  DataBase
+	WebServer WebServer
+	SQS       SQS
 }
 
 type DataBase struct {
@@ -51,9 +25,10 @@ type DataBase struct {
 	ConnectionTimeOut int    // timeout in seconds for trying to connect to the database.
 }
 
-type Server struct {
-	Port  string // the port for the web server to listen for connections on e.g., `8080`
-	CNAME string // the public CNAME for the service.
+type WebServer struct {
+	Port       string // the port for the web server to listen for connections on e.g., `8080`
+	CNAME      string // the public CNAME for the service.
+	Production bool   // set true if the application is running in production mode.
 }
 
 type SQS struct {
@@ -77,6 +52,33 @@ type SQS struct {
 //    var (
 //    	config = cfg.LoadConfig("fits")
 //    )
+//
+// A config JSON file looks like:
+// Config holds configuration applications e.g.,
+//    {
+//    	"DataBase": {
+//    		"Host": "localhost",
+//    		"Name": "fits",
+//    		"User": "fits_r",
+//    		"Password": "test",
+//    		"MaxOpenConns": 30,
+//    		"MaxIdleConns": 20,
+//    		"ConnectionTimeOut": 5,
+//    		"SSLMode": "disable"
+//    	},
+//    	"WebServer": {
+//    		"Port": "8080",
+//                     "CNAME": "my.cool.service"
+//    	            "Production": false
+//    	},
+//           "SQS": {
+// 		"AWSRegion": "ap-southeast-2",
+// 		"QueueName": "XXX",
+// 		"AccessKey": "XXX",
+// 		"SecretKey": "XXX",
+// 		"NumberOfListeners": 1
+// 	},
+//    }
 func Load(name string) Config {
 	log.SetPrefix(name + " ")
 
@@ -109,11 +111,11 @@ func Load(name string) Config {
 }
 
 // Postgres returns a connection string that is suitable for use with sql for connecting to a Postgres DB.
-func (c *Config) Postgres() string {
-	return "host=" + c.DataBase.Host +
-		" connect_timeout=" + strconv.Itoa(c.DataBase.ConnectionTimeOut) +
-		" user=" + c.DataBase.User +
-		" password=" + c.DataBase.Password +
-		" dbname=" + c.DataBase.Name +
-		" sslmode=" + c.DataBase.SSLMode
+func (d *DataBase) Postgres() string {
+	return "host=" + d.Host +
+		" connect_timeout=" + strconv.Itoa(d.ConnectionTimeOut) +
+		" user=" + d.User +
+		" password=" + d.Password +
+		" dbname=" + d.Name +
+		" sslmode=" + d.SSLMode
 }

--- a/cfg/cfg.test.json
+++ b/cfg/cfg.test.json
@@ -1,0 +1,26 @@
+{
+	"DataBase": {
+		"Host": "a",
+		"Name": "b",
+		"User": "c",
+		"Password": "d",
+		"MaxOpenConns": 1, 
+		"MaxIdleConns": 2, 
+		"ConnectionTimeOut": 3,
+		"SSLMode": "e"
+	},
+	"SQS": {
+		"AWSRegion": "f",
+		"QueueName": "g",
+		"AccessKey": "h",
+		"SecretKey": "i",
+		"NumberOfListeners": 4
+	},
+	"Env": {
+		"Prefix": "GO_CFG_TEST"
+	} ,
+	"Librato": {
+		"User": "XXX",
+		"Key": "YYY"
+	}
+}

--- a/cfg/cfg_test.go
+++ b/cfg/cfg_test.go
@@ -1,0 +1,110 @@
+package cfg
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLoad(t *testing.T) {
+	// Load with no env var overrides set.
+	unset()
+
+	c := Load()
+
+	if c.DataBase.Host != "a" {
+		t.Errorf("got %s for DataBase.Host expected %s", c.DataBase.Host, "a")
+	}
+	if c.DataBase.MaxOpenConns != 1 {
+		t.Errorf("got %d for DataBase.MaxOpenConns expected %d", c.DataBase.MaxOpenConns, 1)
+	}
+	if c.WebServer != nil {
+		t.Errorf("Expected nil c.WebServer got %v", c.WebServer)
+	}
+	if c.Librato.User != "XXX" {
+		t.Errorf("got %s for Librato.User expected %s", c.Librato.User, "XXX")
+	}
+
+	// change where Load will look for override files instead of /etc/sysconfig
+	over = "etc"
+
+	c = Load()
+
+	if c.DataBase.Host != "aa" {
+		t.Errorf("got %s for DataBase.Host expected %s", c.DataBase.Host, "aa")
+	}
+	if c.DataBase.MaxOpenConns != 10 {
+		t.Errorf("got %d for DataBase.MaxOpenConns expected %d", c.DataBase.MaxOpenConns, 10)
+	}
+	if !c.WebServer.Production {
+		t.Error("Expected c.WebServer.Production to be true")
+	}
+
+	// load again (from override in etc) but with an env var set
+	set()
+
+	c = Load()
+
+	if c.DataBase.Host != "aaa" {
+		t.Errorf("got %s for DataBase.Host expected %s", c.DataBase.Host, "aaa")
+	}
+	if c.DataBase.MaxOpenConns != 100 {
+		t.Errorf("got %d for DataBase.MaxOpenConns expected %d", c.DataBase.MaxOpenConns, 100)
+	}
+	if c.WebServer.Production {
+		t.Error("Expected c.WebServer.Production to be false")
+	}
+
+	// unset env var and load from local default config.
+	unset()
+	over = "/etc/sysconfig"
+
+	c = Load()
+
+	if c.DataBase.Host != "a" {
+		t.Errorf("got %s for DataBase.Host expected %s", c.DataBase.Host, "a")
+	}
+	if c.DataBase.MaxOpenConns != 1 {
+		t.Errorf("got %d for DataBase.MaxOpenConns expected %d", c.DataBase.MaxOpenConns, 1)
+	}
+
+	// set env and check override of local default config.
+	set()
+
+	c = Load()
+	if c.DataBase.Host != "aaa" {
+		t.Errorf("got %s for DataBase.Host expected %s", c.DataBase.Host, "aaa")
+	}
+	if c.DataBase.MaxOpenConns != 100 {
+		t.Errorf("got %d for DataBase.MaxOpenConns expected %d", c.DataBase.MaxOpenConns, 100)
+	}
+	if c.WebServer != nil {
+		t.Errorf("Expected nil c.WebServer got %v", c.WebServer)
+	}
+	if c.Librato.User != "XXXX" {
+		t.Errorf("got %s for Librato.User expected %s", c.Librato.User, "XXXX")
+	}
+
+	d, err := c.EnvDoc()
+	if err != nil {
+		t.Errorf("Non nil error %s", err)
+	}
+	if len(d) == 0 {
+		t.Error("Zero length for d.")
+	}
+}
+
+func unset() {
+	// Set the test vars empty.
+	// os.Unsetenv is in Go 1.4 but this approach is fine for this use.
+	os.Setenv("GO_CFG_TEST_DATABASE_HOST", "")
+	os.Setenv("GO_CFG_TEST_DATABASE_MAX_OPEN_CONNS", "")
+	os.Setenv("GO_CFG_TEST_WEB_SERVER_PRODUCTION", "")
+	os.Setenv("LIBRATO_USER", "")
+}
+
+func set() {
+	os.Setenv("GO_CFG_TEST_DATABASE_HOST", "aaa")
+	os.Setenv("GO_CFG_TEST_DATABASE_MAX_OPEN_CONNS", "100")
+	os.Setenv("GO_CFG_TEST_WEB_SERVER_PRODUCTION", "false")
+	os.Setenv("LIBRATO_USER", "XXXX")
+}

--- a/cfg/etc/cfg.test.json
+++ b/cfg/etc/cfg.test.json
@@ -1,0 +1,27 @@
+{
+	"DataBase": {
+		"Host": "aa",
+		"Name": "bb",
+		"User": "cc",
+		"Password": "dd",
+		"MaxOpenConns": 10, 
+		"MaxIdleConns": 20, 
+		"ConnectionTimeOut": 30,
+		"SSLMode": "ee"
+	},
+	"SQS": {
+		"AWSRegion": "ff",
+		"QueueName": "gg",
+		"AccessKey": "hh",
+		"SecretKey": "ii",
+		"NumberOfListeners": 40
+	},
+	"WebServer": {
+		"Port": "8080",
+		"CNAME": "jj",
+		"Production": true
+	},
+	"Env": {
+		"Prefix": "GO_CFG_TEST"
+	} 
+}

--- a/tools/configer/configer.go
+++ b/tools/configer/configer.go
@@ -1,0 +1,77 @@
+package main
+
+// an application to read a JSON config file and write a shell script for Docker run that shows
+// env var that can be used to config an application.
+// If using Go 1.4+ can be used with go generate from a code comment e.g.,
+//
+//     //go:generate configer foo.json
+//
+//  then use go generate to create docker-run.sh
+//
+//  See also http://blog.golang.org/generate
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/GeoNet/app/cfg"
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+func main() {
+	if len(os.Args) == 1 {
+		log.Fatal("Please provide a JSON Config file name.")
+	}
+
+	i, err := ioutil.ReadFile(os.Args[1])
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var c cfg.Config
+	err = json.Unmarshal(i, &c)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	d, err := c.EnvDoc()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	f, err := os.Create("docker-run.sh")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+
+	f.WriteString(fmt.Sprintln("#!/bin/bash\n"))
+	f.WriteString(fmt.Sprintln("#"))
+	f.WriteString(fmt.Sprintln("# This file is auto generated.  Do not edit."))
+	f.WriteString(fmt.Sprintln("#"))
+	f.WriteString(fmt.Sprintln("# It was created from the JSON config file and shows the env var that can be used to config the app."))
+	f.WriteString(fmt.Sprintln("# The docker run command will set the env vars on the container."))
+	f.WriteString(fmt.Sprintln("# You will need to adjust the image name in the Docker command."))
+	f.WriteString(fmt.Sprintln("#"))
+	f.WriteString(fmt.Sprintln("# The values shown for the env var are the app defaults from the JSON file."))
+
+	for _, doc := range d {
+		f.WriteString(fmt.Sprintf("#\n# %s\n", doc.Doc))
+		f.WriteString(fmt.Sprintf("# %s=%s\n", doc.Key, doc.Val))
+	}
+
+	f.WriteString(fmt.Sprintln(""))
+
+	f.WriteString(fmt.Sprint("docker run "))
+
+	for _, doc := range d {
+		f.WriteString(fmt.Sprintf("-e \"%s=%s\" ", doc.Key, doc.Val))
+	}
+
+	f.WriteString(fmt.Sprint("busybox\n"))
+
+	f.Sync()
+	f.Chmod(0744)
+	f.Close()
+}


### PR DESCRIPTION
Not much code but a lot to consider.  May need a white board? tldr - a lot of power from one JSON config file.

@ozym - of interest to you as well?  Any comments welcome.

Allows for config override from env var.  Still uses a JSON file with the option to override from /etc/sysconfig  The most useful thing would be a review of the ideas and docs.  The docs on the cfg.Load()  are a good start.

The code uses tags on the structs and reflection to do the work.  

Once this is merged I think configer can be installed with `go get github/GeoNet/app/tools/configer` (I will need to check the deps work ok).  It can then be used with go:generate (with go 1.4).  See the comments in the configer.go.  This can be used in any project using Config to generate a file for docker run (which shows which env var can be set for prod).  Here's an example of the output from that project (branch not yet pushed):

```
#!/bin/bash

#
# This file is auto generated.  Do not edit.
#
# It was created from the JSON config file and shows the env var that can be used to config the app.
# The docker run command will set the env vars on the container.
# You will need to adjust the image name in the Docker command.
#
# The values shown for the env var are the app defaults from the JSON file.
#
# database host name.
# INTENSITY_DATABASE_HOST=localhost
#
# database User password (unencrypted).
# INTENSITY_DATABASE_PASSWORD=test
#
# usually disable or require.
# INTENSITY_DATABASE_SSL_MODE=disable
#
# database connection pool.
# INTENSITY_DATABASE_MAX_OPEN_CONNS=2
#
# database connection pool.
# INTENSITY_DATABASE_MAX_IDLE_CONNS=11
#
# SQS region e.g., ap-southeast-2.
# INTENSITY_SQS_AWS_REGION=ap-southeast-2
#
# SQS queue name.
# INTENSITY_SQS_QUEUE_NAME=XXX
#
# SQS queue user access key.
# INTENSITY_SQS_ACCESS_KEY=XXX
#
# SQS queue user secret.
# INTENSITY_SQS_SECRET_KEY=XXX
#
# number of SQS listeners.
# INTENSITY_SQS_NUMBER_OF_LISTENERS=1
#
# username for Librato.
# LIBRATO_USER=XXX
#
# key for Librato.
# LIBRATO_KEY=XXX

docker run -e "INTENSITY_DATABASE_HOST=localhost" -e "INTENSITY_DATABASE_PASSWORD=test" -e "INTENSITY_DATABASE_SSL_MODE=disable" -e "INTENSITY_DATABASE_MAX_OPEN_CONNS=2" -e "INTENSITY_DATABASE_MAX_IDLE_CONNS=11" -e "INTENSITY_SQS_AWS_REGION=ap-southeast-2" -e "INTENSITY_SQS_QUEUE_NAME=XXX" -e "INTENSITY_SQS_ACCESS_KEY=XXX" -e "INTENSITY_SQS_SECRET_KEY=XXX" -e "INTENSITY_SQS_NUMBER_OF_LISTENERS=1" -e "LIBRATO_USER=XXX" -e "LIBRATO_KEY=XXX" busybox
```